### PR TITLE
Fix script permissions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -59,9 +59,9 @@ COPY library-scripts/linter-*.sh /opt/linter/
 
 RUN \
     chown ${USERNAME}:root /usr/share/illarion/pre-reload && \
-    chmod o+x /usr/share/illarion/pre-reload && \
+    chmod u+x /usr/share/illarion/pre-reload && \
     find /opt/linter -name linter-*.sh | xargs chown ${USERNAME}:root && \
-    find /opt/linter -name linter-*.sh | xargs chmod o+x
+    find /opt/linter -name linter-*.sh | xargs chmod u+x
 
 USER ${USERNAME}
 RUN \


### PR DESCRIPTION
I believe these scripts were meant to be executable by the (u)ser (vscode) and not by (o)thers.

**This fixes vscode linting under linux.**

Maybe this worked on Win10, because WSL2 doesn't implement permissions correctly.

Possible alternatives:
* Grant +x and make scripts executable by everyone
* Commit scripts with desired permissions, since git will retain them. Will this work on Windows, however? Maybe not.